### PR TITLE
Optional tenant in bucket spec for signed multipart uploads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "s3-client-lib"
-version = "0.1.0"
+version = "0.1.1"
 description = "S3 client lib"
 authors = ["Radim Spigel <spigel@cesnet.cz>"]
 

--- a/s3_client_lib/s3_multipart_client.py
+++ b/s3_client_lib/s3_multipart_client.py
@@ -60,11 +60,14 @@ class S3MultipartClient(S3Client):
         return self.signed_s3_multipart_upload(bucket, object_name,)
 
 
-    def signed_s3_multipart_upload(self, bucket, object_name, size, checksum_update, origin, finish_url) -> dict:
+    def signed_s3_multipart_upload(self, bucket, object_name, size, checksum_update,
+                                   origin, finish_url, tenant=None) -> dict:
         self.create_bucket_if_not_exists(bucket)
         upload_id = self.create_multipart_upload(bucket, object_name)
         max_parts, chunk_size = get_file_chunk_size(size)
         logger.debug(f"max parts {max_parts}, chunk size: {chunk_size}")
+        if tenant:
+            bucket = f"{tenant}:{bucket}"
         parts = self.create_presigned_urls_for_multipart_upload(bucket, object_name, upload_id, max_parts)
         return {"parts_url": parts,
                 "chunk_size": chunk_size,


### PR DESCRIPTION
When the target bucket for the multipart upload is owned by a tenant, the bucket spec
needs to be following to match the server signature: `tenant:bucket`